### PR TITLE
Modified parsed_version to keep as string instead of float

### DIFF
--- a/fidvalidator/model_auto.py
+++ b/fidvalidator/model_auto.py
@@ -1,5 +1,6 @@
 import wtforms as wtf
 import csv, json, math
+import re
 
 EXPECTED_LABELS = [str(x + 1) for x in range(32)]
 EXPECTED_DESCS = [
@@ -96,11 +97,11 @@ def csv_to_json(in_csv):
     # Assuming versions are always in the form x.y
     parsed_version = None
     try:
-        parsed_version = float(version_line[-4:])
+        parsed_version = re.findall("\d+\.\d+", version_line)[0]
     except ValueError:
         raise InvalidFcsvError('Invalid Markups fiducial file version')
 
-    if parsed_version < 4.6:
+    if parsed_version < '4.6':
         raise InvalidFcsvError('Markups fiducial file version ' +
                 '{parsed_version} too low'
                 .format(parsed_version=parsed_version))


### PR DESCRIPTION
The current parsed_version line does not work on versions with trailing zeros... etc 4.10. When converting to float, the trailing zero is dropped and the version becomes 4.1, which is too low by definition.

This commit modified the parsing to parse out numbers from the string but keep them as a string. Now the version numbers are evaludated as strings (i.e. '4.10').